### PR TITLE
Fix error for url encoded urls

### DIFF
--- a/src/Controllers/WikipediaController.php
+++ b/src/Controllers/WikipediaController.php
@@ -120,7 +120,7 @@ class WikipediaController
     {
         $segments = explode('/', $wikipedia_url);
 
-        return end($segments);
+        return urldecode(end($segments));
     }
 
     /**


### PR DESCRIPTION
When using an url like https://de.wikipedia.org/wiki/Christian-Albrechts-Universit%C3%A4t_zu_Kiel, the wikipedia api throws an error because of unexpected characters in the page title and therefore won't load the article. 

To prevent this, I've added a simple url decode when the page title is extracted from the provided url.