### PR TITLE
Fix field registration

### DIFF
--- a/src/WikipediaServiceProvider.php
+++ b/src/WikipediaServiceProvider.php
@@ -18,8 +18,6 @@ class WikipediaServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Form::field('wikipedia', WikipediaField::class);
-        Lit::script(__DIR__.'/../dist/index.js');
 
         $loader = AliasLoader::getInstance();
         $loader->alias('Wikipedia', WikipediaFacade::class);
@@ -36,6 +34,9 @@ class WikipediaServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Form::field('wikipedia', WikipediaField::class);
+        Lit::script(__DIR__.'/../dist/index.js');
+
         $this->loadRoutesFrom(__DIR__.'/routes/api.php');
     }
 }


### PR DESCRIPTION
Since Litstack 3.7.7 fields should only be registered after successfully booting the application and when all dependencies from Litstack have been successfully resolved. 
Since `cache` was added as a  dependency to the Litstack `Form` class this needs to be resolved first.