### PR TITLE
fix: add User-Agent header to wikipedia api requests

### DIFF
--- a/src/Controllers/WikipediaController.php
+++ b/src/Controllers/WikipediaController.php
@@ -9,8 +9,12 @@ use Litstack\Wikipedia\Requests\WikipediaPreviewRequest;
 
 class WikipediaController
 {
-    protected string $userAgent = 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)';
+    protected string $userAgent;
 
+    public function __construct()
+    {
+        $this->userAgent = config('lit.fields.wikipedia.user_agent', 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)');
+    }
     /**
      * Load wikipedia content.
      *

--- a/src/Controllers/WikipediaController.php
+++ b/src/Controllers/WikipediaController.php
@@ -50,7 +50,9 @@ class WikipediaController
      */
     protected function getSummary($api_url, $page, ?int $chars = null): string
     {
-        $response = Http::get($api_url, [
+        $response = Http::withHeaders([
+            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+        ])->get($api_url, [
             'format'      => 'json',
             'redirects'   => 1,
             'action'      => 'query',
@@ -86,8 +88,10 @@ class WikipediaController
         if (!$section_id) {
             throw new InvalidArgumentException("The section '$section' was not found.");
         }
-        
-        $response = Http::get($api_url, [
+
+        $response = Http::withHeaders([
+            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+        ])->get($api_url, [
             'action'  => 'parse',
             'format'  => 'json',
             'page'    => $page,
@@ -140,7 +144,9 @@ class WikipediaController
      */
     public function getSectionId(string $api_url, string $section, string $page): int
     {
-        $response = Http::get($api_url, [
+        $response = Http::withHeaders([
+            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+        ])->get($api_url, [
             'format' => 'json',
             'action' => 'parse',
             'prop'   => 'sections',

--- a/src/Controllers/WikipediaController.php
+++ b/src/Controllers/WikipediaController.php
@@ -9,6 +9,8 @@ use Litstack\Wikipedia\Requests\WikipediaPreviewRequest;
 
 class WikipediaController
 {
+    protected string $userAgent = 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)';
+
     /**
      * Load wikipedia content.
      *
@@ -51,7 +53,7 @@ class WikipediaController
     protected function getSummary($api_url, $page, ?int $chars = null): string
     {
         $response = Http::withHeaders([
-            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+            'User-Agent' => $this->userAgent,
         ])->get($api_url, [
             'format'      => 'json',
             'redirects'   => 1,
@@ -90,7 +92,7 @@ class WikipediaController
         }
 
         $response = Http::withHeaders([
-            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+            'User-Agent' => $this->userAgent,
         ])->get($api_url, [
             'action'  => 'parse',
             'format'  => 'json',
@@ -145,7 +147,7 @@ class WikipediaController
     public function getSectionId(string $api_url, string $section, string $page): int
     {
         $response = Http::withHeaders([
-            'User-Agent' => 'LitstackWikipediaClient/1.0 (https://github.com/litstack/wikipedia-field)',
+            'User-Agent' => $this->userAgent,
         ])->get($api_url, [
             'format' => 'json',
             'action' => 'parse',


### PR DESCRIPTION
Currently, the Wikipedia API does not respond and returns a 403 error if no user agent is specified

`"Please set a user-agent and respect our robot policy https://w.wiki/4wJS. See also T400119."`

By setting a generic, package-related user agent, we get the expected functionality back.